### PR TITLE
feat(sse): add exponential backoff and degraded status

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,35 @@ The bridge maintains two status topics:
 
 ## Topic: `.../bridge/miele`
 
-| Value          | Description                |
-| -------------- | -------------------------- |
-| `unknown`      | Unknown connection status  |
-| `connected`    | Miele API is connected     |
-| `disconnected` | Miele API is not connected |
+| Value          | Description                                                                       |
+| -------------- | --------------------------------------------------------------------------------- |
+| `unknown`      | Unknown connection status (initial value)                                         |
+| `connected`    | Miele API is connected (SSE healthy)                                              |
+| `disconnected` | Miele API is not connected (brief failure below backoff threshold)                |
+| `degraded`     | SSE has been failing but polling is still delivering device updates               |
+
+### SSE failure backoff
+
+In `mode: "sse"` the bridge always runs the polling loop alongside SSE as a
+fallback. After several consecutive SSE failures (e.g. the upstream returning
+`504 Gateway Time-out`) the reconnect delay is increased exponentially and the
+bridge reports `degraded` on `bridge/miele` to signal that polling is carrying
+device updates. The defaults are tunable in the config:
+
+```json
+{
+  "miele": {
+    "sse-backoff": {
+      "failure-threshold": 5,
+      "base-delay": "5s",
+      "max-delay": "10m"
+    }
+  }
+}
+```
+
+The `sse-backoff` block is optional. With it omitted, the defaults shown above
+apply.
 
 # run
 
@@ -181,7 +205,7 @@ The bridge exposes a small diagnostic HTTP listener on `:6060`:
           "timeCompleted": "12:35"
         }
       },
-      "sse":     { "last_event": "...", "events_total": 1234 },
+      "sse":     { "last_event": "...", "events_total": 1234, "consecutive_failures": 0, "next_retry_after": "" },
       "polling": { "last_attempt": "...", "last_success": "...", "last_error": "", "success_total": 23, "error_total": 0 },
       "token":   { "expires_at": "...", "last_refresh": "...", "refresh_total": 5 }
     }
@@ -189,6 +213,9 @@ The bridge exposes a small diagnostic HTTP listener on `:6060`:
   ```
 
   Tail a single field with `curl -s http://localhost:6060/debug/vars | jq .miele.sse`.
+  `sse.consecutive_failures` and `sse.next_retry_after` reflect the
+  exponential-backoff state when the upstream is degraded — see
+  [Bridge status](#bridge-status).
 
 - `/debug/pprof/*` — standard Go pprof endpoints (goroutines, heap, CPU, …).
 

--- a/app/app.go
+++ b/app/app.go
@@ -49,10 +49,14 @@ func (a *app) start(ctx context.Context) {
 	a.mgr.SetOnRefresh(metrics.RecordTokenRefresh)
 
 	if a.cfg.Miele.Mode == "sse" {
+		backoff := a.cfg.Miele.SSEBackoff
 		a.sse = sse.Start(sse.Options{
-			AccessToken: a.mgr.CurrentAccessToken,
-			OnDevices:   a.onDevices,
-			OnEvent:     metrics.RecordSSEEvent,
+			AccessToken:      a.mgr.CurrentAccessToken,
+			OnDevices:        a.onDevices,
+			OnEvent:          metrics.RecordSSEEvent,
+			OnPollingHealthy: pollingHealthy,
+			OnFailure:        metrics.RecordSSEFailure,
+			OnSuccess:        metrics.RecordSSESuccess,
 			OnStatus: func(s string) {
 				switch s {
 				case "connected":
@@ -61,9 +65,14 @@ func (a *app) start(ctx context.Context) {
 				case "disconnected":
 					metrics.SetSSEConnection("disconnected")
 					a.pub.PublishMieleState("disconnected")
+				case "degraded":
+					metrics.SetSSEConnection("degraded")
+					a.pub.PublishMieleState("degraded")
 				}
 			},
-			ReconnectDelay: 5 * time.Second,
+			BaseReconnectDelay: backoff.BaseDelayDuration(),
+			MaxReconnectDelay:  backoff.MaxDelayDuration(),
+			FailureThreshold:   backoff.FailureThreshold,
 		})
 	} else {
 		logger.Info("SSE disabled; running in polling-only mode")
@@ -170,6 +179,14 @@ func (a *app) maybeRefresh(ctx context.Context) {
 	if _, err := a.mgr.Login(ctx); err != nil {
 		logger.Error("Re-login failed", "error", err)
 	}
+}
+
+// pollingHealthy reports whether the polling loop has had at least one
+// successful poll since process start. The SSE client uses this to decide
+// whether a sustained failure streak should surface as `degraded` (polling
+// is filling in) or stay on `disconnected` (nothing is working).
+func pollingHealthy() bool {
+	return metrics.PollSuccessTotal() > 0
 }
 
 // stop tears down all background loops.

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/philipparndt/go-logger"
 	gwconfig "github.com/philipparndt/mqtt-gateway/config"
@@ -42,16 +43,55 @@ type TokenConfig struct {
 }
 
 type MieleConfig struct {
-	ClientID                string       `json:"client-id"`
-	ClientSecret            string       `json:"client-secret"`
-	CountryCode             string       `json:"country-code,omitempty"`
-	Username                string       `json:"username,omitempty"`
-	Password                string       `json:"password,omitempty"`
-	Mode                    string       `json:"mode,omitempty"`
-	PollingInterval         int          `json:"polling-interval,omitempty"`
-	Token                   *TokenConfig `json:"token,omitempty"`
-	ConnectionCheckInterval int          `json:"connection-check-interval,omitempty"`
-	PersistToken            bool         `json:"persistToken"`
+	ClientID                string             `json:"client-id"`
+	ClientSecret            string             `json:"client-secret"`
+	CountryCode             string             `json:"country-code,omitempty"`
+	Username                string             `json:"username,omitempty"`
+	Password                string             `json:"password,omitempty"`
+	Mode                    string             `json:"mode,omitempty"`
+	PollingInterval         int                `json:"polling-interval,omitempty"`
+	Token                   *TokenConfig       `json:"token,omitempty"`
+	ConnectionCheckInterval int                `json:"connection-check-interval,omitempty"`
+	PersistToken            bool               `json:"persistToken"`
+	SSEBackoff              *SSEBackoffConfig  `json:"sse-backoff,omitempty"`
+}
+
+// SSEBackoffConfig tunes the exponential reconnect behavior of the SSE client.
+// All fields are optional; defaults are applied by ApplyDefaults.
+type SSEBackoffConfig struct {
+	FailureThreshold int    `json:"failure-threshold,omitempty"`
+	BaseDelay        string `json:"base-delay,omitempty"`
+	MaxDelay         string `json:"max-delay,omitempty"`
+
+	// Parsed durations. Populated by LoadConfig after JSON unmarshalling.
+	// Not part of the JSON schema.
+	baseDelayParsed time.Duration
+	maxDelayParsed  time.Duration
+}
+
+// BaseDelayDuration returns the parsed base-delay. Falls back to a re-parse if
+// the value was set programmatically without going through LoadConfig.
+func (c *SSEBackoffConfig) BaseDelayDuration() time.Duration {
+	if c == nil {
+		return 0
+	}
+	if c.baseDelayParsed > 0 {
+		return c.baseDelayParsed
+	}
+	d, _ := time.ParseDuration(c.BaseDelay)
+	return d
+}
+
+// MaxDelayDuration returns the parsed max-delay. See BaseDelayDuration.
+func (c *SSEBackoffConfig) MaxDelayDuration() time.Duration {
+	if c == nil {
+		return 0
+	}
+	if c.maxDelayParsed > 0 {
+		return c.maxDelayParsed
+	}
+	d, _ := time.ParseDuration(c.MaxDelay)
+	return d
 }
 
 type Config struct {
@@ -102,6 +142,38 @@ func ApplyDefaults(c *Config) {
 	if c.Names == nil {
 		c.Names = make(map[string]string)
 	}
+	if c.Miele.SSEBackoff == nil {
+		c.Miele.SSEBackoff = &SSEBackoffConfig{}
+	}
+	if c.Miele.SSEBackoff.FailureThreshold <= 0 {
+		c.Miele.SSEBackoff.FailureThreshold = 5
+	}
+	if c.Miele.SSEBackoff.BaseDelay == "" {
+		c.Miele.SSEBackoff.BaseDelay = "5s"
+	}
+	if c.Miele.SSEBackoff.MaxDelay == "" {
+		c.Miele.SSEBackoff.MaxDelay = "10m"
+	}
+}
+
+// parseSSEBackoff parses BaseDelay / MaxDelay into time.Duration values and
+// stores them on the SSEBackoffConfig. Returns a wrapped error naming the
+// offending field if either string fails to parse.
+func parseSSEBackoff(b *SSEBackoffConfig) error {
+	if b == nil {
+		return nil
+	}
+	base, err := time.ParseDuration(b.BaseDelay)
+	if err != nil {
+		return fmt.Errorf("miele.sse-backoff.base-delay: %w", err)
+	}
+	max, err := time.ParseDuration(b.MaxDelay)
+	if err != nil {
+		return fmt.Errorf("miele.sse-backoff.max-delay: %w", err)
+	}
+	b.baseDelayParsed = base
+	b.maxDelayParsed = max
+	return nil
 }
 
 // ReplaceEnvVariables substitutes ${NAME} in raw bytes from environment
@@ -140,6 +212,10 @@ func LoadConfig(path string) (Config, error) {
 	}
 
 	ApplyDefaults(&c)
+
+	if err := parseSSEBackoff(c.Miele.SSEBackoff); err != nil {
+		return Config{}, fmt.Errorf("parse config %s: %w", path, err)
+	}
 
 	mu.Lock()
 	cfg = c

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestReplaceEnvVariables(t *testing.T) {
@@ -208,6 +209,100 @@ func TestBridgeInfoTopic_Override(t *testing.T) {
 	c := Config{MQTT: MQTTConfig{Topic: "home/miele", BridgeInfoTopic: "custom/topic"}}
 	if got := c.BridgeInfoTopic(); got != "custom/topic" {
 		t.Errorf("BridgeInfoTopic = %q, want custom/topic", got)
+	}
+}
+
+func TestLoadConfig_SSEBackoffDefaults(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "config.json")
+	body := `{"mqtt": {"url": "tcp://localhost:1883", "topic": "miele"}}`
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	b := c.Miele.SSEBackoff
+	if b == nil {
+		t.Fatal("SSEBackoff should be populated with defaults")
+	}
+	if b.FailureThreshold != 5 {
+		t.Errorf("FailureThreshold = %d, want 5", b.FailureThreshold)
+	}
+	if b.BaseDelayDuration() != 5*time.Second {
+		t.Errorf("BaseDelay = %v, want 5s", b.BaseDelayDuration())
+	}
+	if b.MaxDelayDuration() != 10*time.Minute {
+		t.Errorf("MaxDelay = %v, want 10m", b.MaxDelayDuration())
+	}
+}
+
+func TestLoadConfig_SSEBackoffPartialOverride(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "config.json")
+	body := `{
+        "mqtt": {"url": "tcp://localhost:1883", "topic": "miele"},
+        "miele": {"sse-backoff": {"failure-threshold": 10}}
+    }`
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	b := c.Miele.SSEBackoff
+	if b.FailureThreshold != 10 {
+		t.Errorf("FailureThreshold = %d, want 10", b.FailureThreshold)
+	}
+	if b.BaseDelayDuration() != 5*time.Second {
+		t.Errorf("BaseDelay = %v, want default 5s", b.BaseDelayDuration())
+	}
+	if b.MaxDelayDuration() != 10*time.Minute {
+		t.Errorf("MaxDelay = %v, want default 10m", b.MaxDelayDuration())
+	}
+}
+
+func TestLoadConfig_SSEBackoffCustomDurations(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "config.json")
+	body := `{
+        "mqtt": {"url": "tcp://localhost:1883", "topic": "miele"},
+        "miele": {"sse-backoff": {"base-delay": "2s", "max-delay": "5m"}}
+    }`
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	b := c.Miele.SSEBackoff
+	if b.BaseDelayDuration() != 2*time.Second {
+		t.Errorf("BaseDelay = %v, want 2s", b.BaseDelayDuration())
+	}
+	if b.MaxDelayDuration() != 5*time.Minute {
+		t.Errorf("MaxDelay = %v, want 5m", b.MaxDelayDuration())
+	}
+}
+
+func TestLoadConfig_SSEBackoffInvalidDuration(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "config.json")
+	body := `{
+        "mqtt": {"url": "tcp://localhost:1883", "topic": "miele"},
+        "miele": {"sse-backoff": {"base-delay": "five seconds"}}
+    }`
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadConfig(p)
+	if err == nil {
+		t.Fatal("expected error for invalid duration")
+	}
+	if !strings.Contains(err.Error(), "base-delay") {
+		t.Errorf("error should name the offending field, got: %v", err)
 	}
 }
 

--- a/app/metrics/metrics.go
+++ b/app/metrics/metrics.go
@@ -27,8 +27,10 @@ type state struct {
 
 	devices map[string]transform.SmallMessage
 
-	sseLastEvent     time.Time
-	sseEventsTotal   atomic.Int64
+	sseLastEvent            time.Time
+	sseEventsTotal          atomic.Int64
+	sseConsecutiveFailures  int
+	sseNextRetryAt          time.Time
 
 	pollLastAttempt  time.Time
 	pollLastSuccess  time.Time
@@ -66,12 +68,19 @@ func snapshot() any {
 		devicesCopy[k] = v
 	}
 
+	nextRetry := ""
+	if !s.sseNextRetryAt.IsZero() {
+		nextRetry = s.sseNextRetryAt.Format(time.RFC3339)
+	}
+
 	return map[string]any{
 		"connection": s.connection,
 		"devices":    devicesCopy,
 		"sse": map[string]any{
-			"last_event":   s.sseLastEvent,
-			"events_total": s.sseEventsTotal.Load(),
+			"last_event":           s.sseLastEvent,
+			"events_total":         s.sseEventsTotal.Load(),
+			"consecutive_failures": s.sseConsecutiveFailures,
+			"next_retry_after":     nextRetry,
 		},
 		"polling": map[string]any{
 			"last_attempt":  s.pollLastAttempt,
@@ -102,6 +111,30 @@ func RecordSSEEvent(now time.Time) {
 	s.sseLastEvent = now
 	s.mu.Unlock()
 	s.sseEventsTotal.Add(1)
+}
+
+// RecordSSEFailure records the current consecutive-failure streak and the
+// time of the next scheduled reconnect attempt.
+func RecordSSEFailure(streak int, nextRetry time.Time) {
+	s.mu.Lock()
+	s.sseConsecutiveFailures = streak
+	s.sseNextRetryAt = nextRetry
+	s.mu.Unlock()
+}
+
+// RecordSSESuccess resets the SSE failure-streak metrics after a successful
+// event dispatch.
+func RecordSSESuccess() {
+	s.mu.Lock()
+	s.sseConsecutiveFailures = 0
+	s.sseNextRetryAt = time.Time{}
+	s.mu.Unlock()
+}
+
+// PollSuccessTotal returns the cumulative number of successful poll cycles.
+// Used by the app to decide whether polling is "healthy" for status reporting.
+func PollSuccessTotal() int64 {
+	return s.pollSuccessTotal.Load()
 }
 
 // RecordDevice replaces the snapshot for a single device id.

--- a/app/metrics/metrics_test.go
+++ b/app/metrics/metrics_test.go
@@ -44,6 +44,12 @@ func TestSnapshot_DefaultShape(t *testing.T) {
 	if v, _ := sseSection["events_total"].(int64); v != 0 {
 		t.Errorf("events_total = %v, want 0", sseSection["events_total"])
 	}
+	if v, _ := sseSection["consecutive_failures"].(int); v != 0 {
+		t.Errorf("consecutive_failures = %v, want 0", sseSection["consecutive_failures"])
+	}
+	if v, _ := sseSection["next_retry_after"].(string); v != "" {
+		t.Errorf("next_retry_after = %q, want empty", v)
+	}
 
 	pollingSection := snap["polling"].(map[string]any)
 	if v, _ := pollingSection["success_total"].(int64); v != 0 {
@@ -86,6 +92,32 @@ func TestRecordSSEEvent(t *testing.T) {
 	}
 	if !sse["last_event"].(time.Time).Equal(now.Add(time.Minute)) {
 		t.Errorf("last_event = %v, want %v", sse["last_event"], now.Add(time.Minute))
+	}
+}
+
+func TestRecordSSEFailureAndSuccess(t *testing.T) {
+	resetState()
+	retry := time.Date(2026, 1, 2, 12, 0, 30, 0, time.UTC)
+
+	RecordSSEFailure(1, retry)
+	RecordSSEFailure(2, retry.Add(time.Second))
+	RecordSSEFailure(3, retry.Add(2*time.Second))
+
+	sse := snapshot().(map[string]any)["sse"].(map[string]any)
+	if sse["consecutive_failures"].(int) != 3 {
+		t.Errorf("consecutive_failures = %v, want 3", sse["consecutive_failures"])
+	}
+	if sse["next_retry_after"].(string) == "" {
+		t.Error("next_retry_after should be set after failures")
+	}
+
+	RecordSSESuccess()
+	sse = snapshot().(map[string]any)["sse"].(map[string]any)
+	if sse["consecutive_failures"].(int) != 0 {
+		t.Errorf("consecutive_failures should reset to 0 on success, got %v", sse["consecutive_failures"])
+	}
+	if sse["next_retry_after"].(string) != "" {
+		t.Errorf("next_retry_after should be empty on success, got %v", sse["next_retry_after"])
 	}
 }
 

--- a/app/miele/sse/sse.go
+++ b/app/miele/sse/sse.go
@@ -31,14 +31,40 @@ type Options struct {
 	// OnEvent fires once per successfully-dispatched event with the time of
 	// dispatch. Used by metrics; may be nil.
 	OnEvent func(now time.Time)
-	// OnStatus is invoked with `connected` after the body opens and
-	// `disconnected` whenever a stream ends. May be nil.
+	// OnStatus is invoked with `connected` after the body opens and an event
+	// is dispatched (or `connected` is held), `disconnected` whenever a stream
+	// ends below the backoff threshold, and `degraded` when the failure streak
+	// reaches the threshold while polling is healthy. May be nil.
 	OnStatus func(state string)
+	// OnPollingHealthy reports whether the parallel polling loop has had at
+	// least one successful poll since process start. When non-nil and the
+	// failure streak has reached FailureThreshold, the status callback emits
+	// `degraded` instead of `disconnected`. May be nil (treated as always
+	// false — i.e. the bridge stays on `disconnected`).
+	OnPollingHealthy func() bool
+	// OnFailure fires once per registered failure with the post-increment
+	// streak count and the absolute time of the next reconnect attempt. Used
+	// by metrics; may be nil.
+	OnFailure func(streak int, nextRetry time.Time)
+	// OnSuccess fires once on the first successful event dispatch that resets
+	// the streak. Used by metrics; may be nil.
+	OnSuccess func()
 	// WatchdogTimeout, if >0, closes the active stream when no event has been
 	// received for that long. Mirrors hue-to-mqtt-gw's watchdog.
 	WatchdogTimeout time.Duration
-	// ReconnectDelay between attempts. Defaults to 5s.
+	// ReconnectDelay between attempts. Kept for back-compat; if set and
+	// BaseReconnectDelay is unset, it is used as the base delay. Defaults to
+	// 5s when both are unset.
 	ReconnectDelay time.Duration
+	// BaseReconnectDelay is the delay between attempts while the consecutive
+	// failure streak is below FailureThreshold.
+	BaseReconnectDelay time.Duration
+	// MaxReconnectDelay caps the step-table delay used at and beyond the
+	// failure threshold.
+	MaxReconnectDelay time.Duration
+	// FailureThreshold is the consecutive-failure count at which the backoff
+	// step table engages. Defaults to 5 when zero.
+	FailureThreshold int
 	// HTTPClient lets tests swap the transport.
 	HTTPClient *http.Client
 	// URL lets tests point at a stub server.
@@ -50,12 +76,20 @@ type Options struct {
 type Client struct {
 	opts Options
 
-	mu        sync.Mutex
-	resp      *http.Response
-	lastEvent time.Time
-	stopOnce  sync.Once
-	stopCh    chan struct{}
-	watchdog  *time.Ticker
+	// backoffTable holds the precomputed step values used at and beyond
+	// FailureThreshold. The last entry equals MaxReconnectDelay.
+	backoffTable []time.Duration
+
+	mu                       sync.Mutex
+	resp                     *http.Response
+	lastEvent                time.Time
+	stopOnce                 sync.Once
+	stopCh                   chan struct{}
+	watchdog                 *time.Ticker
+	consecutiveFailures      int
+	dispatchedThisConnection bool
+	nextRetryAt              time.Time
+	lastStatus               string
 }
 
 // Start launches the SSE client in a goroutine and returns it. Call Stop to
@@ -67,12 +101,44 @@ func Start(opts Options) *Client {
 	if opts.URL == "" {
 		opts.URL = URL
 	}
-	if opts.ReconnectDelay <= 0 {
-		opts.ReconnectDelay = 5 * time.Second
+	if opts.BaseReconnectDelay <= 0 {
+		if opts.ReconnectDelay > 0 {
+			opts.BaseReconnectDelay = opts.ReconnectDelay
+		} else {
+			opts.BaseReconnectDelay = 5 * time.Second
+		}
+	}
+	if opts.MaxReconnectDelay <= 0 {
+		opts.MaxReconnectDelay = 10 * time.Minute
+	}
+	if opts.MaxReconnectDelay < opts.BaseReconnectDelay {
+		opts.MaxReconnectDelay = opts.BaseReconnectDelay
+	}
+	if opts.FailureThreshold <= 0 {
+		opts.FailureThreshold = 5
 	}
 	c := &Client{opts: opts, stopCh: make(chan struct{})}
+	c.backoffTable = buildBackoffTable(opts.BaseReconnectDelay, opts.MaxReconnectDelay)
 	go c.loop()
 	return c
+}
+
+// buildBackoffTable returns the step delays applied at and beyond the failure
+// threshold. The first step is meaningfully larger than the base (~6x) and
+// the last entry equals max. Steps grow ~6x each so the default 5s→10m chain
+// is 30s, 3m, 10m; a 5s base with 10m max yields [30s, 3m, 10m].
+func buildBackoffTable(base, max time.Duration) []time.Duration {
+	if max <= base {
+		return []time.Duration{max}
+	}
+	table := []time.Duration{}
+	d := base * 6
+	for d < max {
+		table = append(table, d)
+		d *= 6
+	}
+	table = append(table, max)
+	return table
 }
 
 // Stop ends the read loop and closes any active connection. Safe to call
@@ -101,16 +167,129 @@ func (c *Client) loop() {
 
 		c.connect()
 
-		if c.opts.OnStatus != nil {
-			c.opts.OnStatus("disconnected")
+		// Connect returned; this attempt produced no further events. If no
+		// event was dispatched on this connection, count it as a failure.
+		c.mu.Lock()
+		dispatched := c.dispatchedThisConnection
+		c.mu.Unlock()
+		if !dispatched {
+			c.recordFailure()
 		}
+
+		delay := c.selectBackoffDelay()
+		c.emitPostAttemptStatus()
 
 		select {
 		case <-c.stopCh:
 			return
-		case <-time.After(c.opts.ReconnectDelay):
+		case <-time.After(delay):
 			logger.Info("[SSE] Reconnecting...")
 		}
+	}
+}
+
+// selectBackoffDelay picks the next reconnect delay and updates nextRetryAt.
+// Returns the base delay while below threshold; otherwise the step-table
+// value at index (streak - threshold), saturating at the last entry.
+func (c *Client) selectBackoffDelay() time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var delay time.Duration
+	if c.consecutiveFailures < c.opts.FailureThreshold {
+		delay = c.opts.BaseReconnectDelay
+	} else {
+		idx := c.consecutiveFailures - c.opts.FailureThreshold
+		if idx >= len(c.backoffTable) {
+			idx = len(c.backoffTable) - 1
+		}
+		delay = c.backoffTable[idx]
+	}
+	c.nextRetryAt = time.Now().Add(delay)
+	return delay
+}
+
+// emitPostAttemptStatus signals `degraded` when the streak has crossed the
+// threshold and polling is healthy; otherwise emits `disconnected`. Called
+// once per connect attempt after the attempt has ended.
+func (c *Client) emitPostAttemptStatus() {
+	if c.opts.OnStatus == nil {
+		return
+	}
+	c.mu.Lock()
+	streak := c.consecutiveFailures
+	threshold := c.opts.FailureThreshold
+	c.mu.Unlock()
+
+	status := "disconnected"
+	if streak >= threshold && c.pollingHealthy() {
+		status = "degraded"
+	}
+	c.emitStatus(status)
+}
+
+// emitStatus calls OnStatus only when the new state differs from the
+// last-emitted state — this keeps MQTT publishes idempotent across retries.
+func (c *Client) emitStatus(state string) {
+	if c.opts.OnStatus == nil {
+		return
+	}
+	c.mu.Lock()
+	same := c.lastStatus == state
+	c.lastStatus = state
+	c.mu.Unlock()
+	if !same {
+		c.opts.OnStatus(state)
+	}
+}
+
+func (c *Client) pollingHealthy() bool {
+	if c.opts.OnPollingHealthy == nil {
+		return false
+	}
+	return c.opts.OnPollingHealthy()
+}
+
+// recordFailure increments the streak and notifies metrics.
+func (c *Client) recordFailure() {
+	c.mu.Lock()
+	c.consecutiveFailures++
+	streak := c.consecutiveFailures
+	c.mu.Unlock()
+
+	if c.opts.OnFailure != nil {
+		// Estimate the next-retry timestamp using the same logic as
+		// selectBackoffDelay would compute; the loop will overwrite it
+		// immediately, but this gives metrics readers a consistent value.
+		c.opts.OnFailure(streak, c.estimateNextRetry(streak))
+	}
+}
+
+func (c *Client) estimateNextRetry(streak int) time.Time {
+	var delay time.Duration
+	if streak < c.opts.FailureThreshold {
+		delay = c.opts.BaseReconnectDelay
+	} else {
+		idx := streak - c.opts.FailureThreshold
+		if idx >= len(c.backoffTable) {
+			idx = len(c.backoffTable) - 1
+		}
+		delay = c.backoffTable[idx]
+	}
+	return time.Now().Add(delay)
+}
+
+// recordSuccess resets the streak on first event dispatch after a (re)connect.
+func (c *Client) recordSuccess() {
+	c.mu.Lock()
+	hadStreak := c.consecutiveFailures > 0
+	c.consecutiveFailures = 0
+	c.dispatchedThisConnection = true
+	c.nextRetryAt = time.Time{}
+	c.mu.Unlock()
+
+	if hadStreak && c.opts.OnSuccess != nil {
+		c.opts.OnSuccess()
 	}
 }
 
@@ -120,6 +299,11 @@ func (c *Client) connect() {
 		logger.Warn("[SSE] No access token, skipping connect")
 		return
 	}
+
+	c.mu.Lock()
+	c.dispatchedThisConnection = false
+	c.nextRetryAt = time.Time{}
+	c.mu.Unlock()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -154,9 +338,10 @@ func (c *Client) connect() {
 
 	c.startWatchdog()
 
-	if c.opts.OnStatus != nil {
-		c.opts.OnStatus("connected")
-	}
+	// Body opened — emit connected. If a dispatch follows, it stays connected;
+	// if the body ends without a dispatch, the loop will register a failure
+	// and may flip to disconnected/degraded on the next attempt.
+	c.emitStatus("connected")
 	logger.Info("[SSE] Connected, reading events")
 
 	c.readLoop(resp)
@@ -214,6 +399,10 @@ func (c *Client) readLoop(resp *http.Response) {
 		if c.opts.OnDevices != nil {
 			c.opts.OnDevices(devs)
 		}
+		// A successful dispatch resets the streak and re-asserts `connected`
+		// (no-op if already connected).
+		c.recordSuccess()
+		c.emitStatus("connected")
 	}
 
 	for scanner.Scan() {

--- a/app/miele/sse/sse_test.go
+++ b/app/miele/sse/sse_test.go
@@ -293,6 +293,266 @@ func TestSSE_NoTokenSkipsConnect(t *testing.T) {
 	}
 }
 
+// failingHandler returns 504 for the first `failures` requests and then 200
+// with a single `devices` event on the next request. Each request increments
+// the counter.
+func failingHandler(failures *atomic.Int32, threshold int32) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		n := failures.Add(1)
+		if n <= threshold {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fw := newFlushWriter(w)
+		fw.Write("event: devices\n")
+		fw.Write("data: {\"ok\":{\"x\":1}}\n")
+		fw.Write("\n")
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func TestSSE_BackoffSteps_DegradedAndRecovery(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(failingHandler(&attempts, 3))
+	t.Cleanup(srv.Close)
+
+	var (
+		mu       sync.Mutex
+		states   []string
+		failures int
+		success  bool
+	)
+	dispatched := make(chan struct{}, 1)
+	polling := atomic.Bool{}
+	polling.Store(true) // polling is "healthy" for this test
+
+	c := Start(Options{
+		AccessToken:        func() string { return "T" },
+		URL:                srv.URL,
+		HTTPClient:         srv.Client(),
+		BaseReconnectDelay: 10 * time.Millisecond,
+		MaxReconnectDelay:  60 * time.Millisecond,
+		FailureThreshold:   2,
+		OnPollingHealthy:   func() bool { return polling.Load() },
+		OnStatus: func(s string) {
+			mu.Lock()
+			states = append(states, s)
+			mu.Unlock()
+		},
+		OnFailure: func(_ int, _ time.Time) {
+			mu.Lock()
+			failures++
+			mu.Unlock()
+		},
+		OnSuccess: func() {
+			mu.Lock()
+			success = true
+			mu.Unlock()
+		},
+		OnDevices: func(_ []api.Device) {
+			select {
+			case dispatched <- struct{}{}:
+			default:
+			}
+		},
+	})
+	defer c.Stop()
+
+	select {
+	case <-dispatched:
+	case <-time.After(3 * time.Second):
+		t.Fatal("never received a dispatched event after recovery")
+	}
+
+	// Give the loop a moment to emit `connected` after dispatch.
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if failures < 3 {
+		t.Errorf("failures = %d, want >= 3", failures)
+	}
+	if !success {
+		t.Error("expected OnSuccess to fire after recovery")
+	}
+	sawDegraded := false
+	sawDisconnected := false
+	sawConnected := false
+	for _, s := range states {
+		switch s {
+		case "degraded":
+			sawDegraded = true
+		case "disconnected":
+			sawDisconnected = true
+		case "connected":
+			sawConnected = true
+		}
+	}
+	if !sawDisconnected {
+		t.Errorf("expected `disconnected` state below threshold, got %v", states)
+	}
+	if !sawDegraded {
+		t.Errorf("expected `degraded` state at/beyond threshold, got %v", states)
+	}
+	if !sawConnected {
+		t.Errorf("expected `connected` after recovery, got %v", states)
+	}
+}
+
+func TestSSE_DegradedRequiresPollingHealthy(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(failingHandler(&attempts, 1000)) // always fail
+	t.Cleanup(srv.Close)
+
+	var (
+		mu     sync.Mutex
+		states []string
+	)
+	c := Start(Options{
+		AccessToken:        func() string { return "T" },
+		URL:                srv.URL,
+		HTTPClient:         srv.Client(),
+		BaseReconnectDelay: 5 * time.Millisecond,
+		MaxReconnectDelay:  20 * time.Millisecond,
+		FailureThreshold:   2,
+		OnPollingHealthy:   func() bool { return false }, // polling never healthy
+		OnStatus: func(s string) {
+			mu.Lock()
+			states = append(states, s)
+			mu.Unlock()
+		},
+	})
+	defer c.Stop()
+
+	// Wait long enough for several failures past the threshold.
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, s := range states {
+		if s == "degraded" {
+			t.Errorf("must not emit `degraded` when polling is unhealthy, states = %v", states)
+		}
+	}
+	sawDisconnected := false
+	for _, s := range states {
+		if s == "disconnected" {
+			sawDisconnected = true
+		}
+	}
+	if !sawDisconnected {
+		t.Errorf("expected `disconnected`, got %v", states)
+	}
+}
+
+func TestSSE_BodyOpensButNoEventCountsAsFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Return immediately — body closes without an event.
+	}))
+	t.Cleanup(srv.Close)
+
+	var failures atomic.Int32
+	c := Start(Options{
+		AccessToken:        func() string { return "T" },
+		URL:                srv.URL,
+		HTTPClient:         srv.Client(),
+		BaseReconnectDelay: 5 * time.Millisecond,
+		MaxReconnectDelay:  20 * time.Millisecond,
+		FailureThreshold:   100, // keep us in base-delay regime
+		OnFailure: func(_ int, _ time.Time) {
+			failures.Add(1)
+		},
+	})
+	defer c.Stop()
+
+	// Allow several connect attempts.
+	time.Sleep(120 * time.Millisecond)
+
+	if failures.Load() < 3 {
+		t.Errorf("expected >= 3 failures from silent-stream connections, got %d", failures.Load())
+	}
+}
+
+func TestSSE_WatchdogTimeoutAfterDispatchDoesNotCount(t *testing.T) {
+	// Server dispatches one event, then holds the connection open without
+	// emitting anything else. Watchdog will fire, but since an event was
+	// dispatched the failure counter must stay at 0.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fw := newFlushWriter(w)
+		fw.Write("event: devices\n")
+		fw.Write("data: {\"d1\":{\"x\":1}}\n")
+		fw.Write("\n")
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	var failures atomic.Int32
+	dispatched := make(chan struct{}, 1)
+
+	c := Start(Options{
+		AccessToken:        func() string { return "T" },
+		URL:                srv.URL,
+		HTTPClient:         srv.Client(),
+		BaseReconnectDelay: 200 * time.Millisecond,
+		MaxReconnectDelay:  500 * time.Millisecond,
+		FailureThreshold:   100,
+		WatchdogTimeout:    60 * time.Millisecond,
+		OnFailure: func(_ int, _ time.Time) {
+			failures.Add(1)
+		},
+		OnDevices: func(_ []api.Device) {
+			select {
+			case dispatched <- struct{}{}:
+			default:
+			}
+		},
+	})
+	defer c.Stop()
+
+	select {
+	case <-dispatched:
+	case <-time.After(2 * time.Second):
+		t.Fatal("never dispatched")
+	}
+	// Watchdog will trigger ~60ms after dispatch. Give it time to fire and
+	// then ensure no failure was recorded for this connection.
+	time.Sleep(150 * time.Millisecond)
+
+	if failures.Load() != 0 {
+		t.Errorf("watchdog fired after a dispatch — must not count as failure, got %d", failures.Load())
+	}
+}
+
+func TestBuildBackoffTable(t *testing.T) {
+	table := buildBackoffTable(5*time.Second, 10*time.Minute)
+	if len(table) == 0 {
+		t.Fatal("empty table")
+	}
+	if table[0] <= 5*time.Second {
+		t.Errorf("first step %v should be > base 5s", table[0])
+	}
+	if table[len(table)-1] != 10*time.Minute {
+		t.Errorf("last step %v should equal max 10m", table[len(table)-1])
+	}
+	for i := 1; i < len(table); i++ {
+		if table[i] < table[i-1] {
+			t.Errorf("table must be monotonically non-decreasing: %v", table)
+		}
+	}
+
+	// Edge: max <= base produces a single-step table.
+	single := buildBackoffTable(10*time.Second, 5*time.Second)
+	if len(single) != 1 {
+		t.Errorf("max <= base should yield one step, got %v", single)
+	}
+}
+
 func TestSSE_DataLineWithoutSpaceAfterColon(t *testing.T) {
 	// SSE allows `data:foo` (no space after colon). The hue-style reader in
 	// the original code uses `strings.HasPrefix(line, "data: ")` and would

--- a/config-example.json
+++ b/config-example.json
@@ -12,7 +12,12 @@
         "client-id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "client-secret": "12345678901234567890123456789012",
         "username": "miele_at_home_user@example.com",
-        "password": "miele_at_home_password"
+        "password": "miele_at_home_password",
+        "sse-backoff": {
+            "failure-threshold": 5,
+            "base-delay": "5s",
+            "max-delay": "10m"
+        }
     },
     "timezone": "GMT+1"
 }

--- a/openspec/changes/archive/2026-05-17-sse-failure-backoff/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-17-sse-failure-backoff/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-17-sse-failure-backoff/design.md
+++ b/openspec/changes/archive/2026-05-17-sse-failure-backoff/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The Go SSE client in `app/miele/sse/sse.go` runs a tight loop: connect → read → on any failure, log, wait `ReconnectDelay` (default 5s), repeat. There is no failure-streak tracking and no awareness that the upstream might be sustained-down. During the outage reported in issue #45, the Miele API's openresty layer returned `504 Gateway Time-out` after ~60s for every connect attempt. With a 5s base delay, the bridge made ~720 doomed connections per hour while polling (which runs in parallel since commit `7620b8e`) silently kept delivering device updates.
+
+The MQTT bridge status published on `bridge/miele` only has two non-initial values today: `connected` and `disconnected`. From an operator perspective `disconnected` flickers in and out during the outage, even though the bridge is actually fine — polling is filling in. There is no way to express "SSE is degraded, polling is carrying us".
+
+The polling loop and the device-update path (`onDevices`) are already mode-agnostic. So this change is bounded to the SSE side: smarter retry pacing and a clearer status surface.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Stop hammering a known-failing SSE endpoint while preserving fast recovery on a single transient blip.
+- Give operators a clear `degraded` bridge state that distinguishes "SSE is broken but device updates still flow" from "everything is broken".
+- Keep the existing config schema valid (defaults match current behavior on the first ~25 seconds of any outage).
+- Surface enough diagnostic state in the existing `miele` expvar that an operator can see *why* the bridge is in degraded mode without reading logs.
+
+**Non-Goals:**
+
+- Boosting the polling interval when SSE is degraded. Polling already runs at its configured interval; if operators want faster updates during an SSE outage they can tune `miele.polling-interval`. A dynamic polling interval would complicate the dedup story and the recovery path with little real-world benefit.
+- Switching the configured `miele.mode` value at runtime. The mode stays `sse`; what changes is the SSE client's reconnect pacing and the reported status. `mode=polling` users are unaffected by this change.
+- Circuit-breaker semantics that stop SSE entirely. The SSE attempt always continues, just spaced out — so as soon as Miele recovers we notice within the current max-delay window (10 minutes by default).
+- Notifications/alerting integrations. The `degraded` state on the existing MQTT topic and the expvar fields are the surface; operators can build alerts on top.
+
+## Decisions
+
+### Backoff scheme: exponential with a step table
+
+Reconnect delay is selected from a fixed step table, not computed from a multiplier. Steps: `5s, 30s, 2m, 10m`. The index advances by one each failure starting at the configured threshold (default 5) and saturates at the last step. On a successful event dispatch, the index resets to 0 (so the next reconnect delay is the base 5s).
+
+*Alternatives considered:*
+
+- **Multiplicative backoff (`delay *= 2`, cap at 10m).** Cleaner code but the early-outage curve is too aggressive: 5s, 10s, 20s, 40s, 80s … crossing the minute mark only at the 5th failure. The step table jumps to 30s on the first triggered step which is what we actually want.
+- **Jitter on each delay.** Worth doing if many bridges hit the same Miele tenant at once, but in practice this is a personal/self-hosted bridge with one connection — adding jitter would obscure debug output without measurable benefit.
+
+### Failure counted: anything that ends a connect attempt without successfully dispatching an event
+
+The streak counter increments for any of: failed request build, HTTP transport error, non-200 response (including 504), EOF on the body before any event has been dispatched on that connection, watchdog timeout. It resets when a `devices` event successfully dispatches.
+
+*Rationale:* A 504 from openresty is a non-200; an upstream timeout often manifests as a slow EOF. Treating "connected once but never received a real event" as a failure correctly classifies the issue-#45 mode where the response opens and then dies. The success criterion is *event dispatched*, not *body opened*, because Miele's behavior during the outage was to open the body and silently never deliver an event.
+
+*Alternatives considered:* counting only HTTP errors. Rejected — misses the silent-stream failure mode which is exactly what issue #45 hit. (Their case happened to surface as 504 after openresty's own timeout, but other outages have presented as a connected body that never emits.)
+
+### Status reporting: add `degraded` between `connected` and `disconnected`
+
+The SSE client gains an `OnStatus("degraded")` call when the failure streak crosses the threshold while polling is healthy. `connected` is emitted on first successful event after a degraded period. `disconnected` keeps its current meaning (per-attempt connection state during the brief window before the threshold).
+
+In `app.go` the status callback maps to MQTT `bridge/miele` and to `metrics.SetSSEConnection`. The metrics package already accepts an arbitrary string; only the MQTT side and README need a documented enum.
+
+*Why a new state instead of overloading `disconnected`:* operators tune Home Assistant / openHAB alerts on `bridge/miele`. Today a flapping `disconnected` is a true alert ("SSE is broken"). After this change `disconnected` keeps that meaning, and `degraded` becomes a separate, longer-lived signal that operators can choose to alert on or ignore.
+
+### Config shape: nested optional block
+
+```jsonc
+{
+  "miele": {
+    "sse-backoff": {
+      "failure-threshold": 5,    // streak count at which backoff engages
+      "base-delay": "5s",        // delay before threshold is hit
+      "max-delay": "10m"         // ceiling for the step table
+    }
+  }
+}
+```
+
+All three fields are optional. Delays are parsed with `time.ParseDuration` so operators can write `"5s"`, `"500ms"`, etc. Missing values get the defaults stated above. The step table between `base-delay` and `max-delay` is computed (multiply by ~6 each step) rather than configurable per-step — keeping the config simple.
+
+*Alternatives considered:* flat top-level keys (`miele.sse-backoff-threshold`, …). Rejected — three related keys read better grouped, and the existing config style already groups related fields under nested objects (`miele.token`, `mqtt`).
+
+### Expvar additions: `sse.consecutive_failures` and `sse.next_retry_after`
+
+`consecutive_failures` is the current streak (`int`). `next_retry_after` is the RFC3339 timestamp at which the next reconnect will fire (empty string when not in a wait). Both update at the same callsites as the existing `sse.last_event` and `sse.events_total`.
+
+## Risks / Trade-offs
+
+- **Operators may not notice the new `degraded` value.** Mitigation: documented in README under the bridge-status table, and the expvar exposes the streak so a curious operator can see it.
+- **A real Miele incident lasting >10m means a 10-minute recovery window after the upstream comes back.** Mitigation: the max delay is configurable; default 10m is a deliberate trade-off against connection-attempt cost.
+- **Resetting on first dispatched event misses partial-recovery cases** where Miele dispatches one event then stalls. The watchdog (already in place) will catch the stall and re-engage backoff. Net result is one extra "burned" base-delay step, which is acceptable.
+- **The status callback is now called more often per state** (each transition rather than each connect attempt). The MQTT publisher deduplicates on the bridge topic via the existing retain semantics, so this is a no-op on the wire.
+
+## Migration Plan
+
+1. Ship the change with defaults that match current behavior on short outages (<25s). Existing configs require no edits.
+2. README updates: bridge-status enum gains `degraded`; document the new `miele.sse-backoff` block as optional with its defaults.
+3. Rollback: removing the change reverts to fixed 5s reconnects. Persisted tokens and MQTT contract are unaffected, so rollback is a clean binary swap.
+
+## Open Questions
+
+- Should the bridge publish `degraded` immediately at startup when the first SSE attempt fails but polling has not yet had a chance to succeed? **Decision:** No — keep `disconnected` for that case so the existing meaning holds. `degraded` requires the streak threshold to be crossed *and* at least one successful poll on the parallel polling loop. If polling has not yet succeeded, the bridge is genuinely disconnected from the user's perspective.

--- a/openspec/changes/archive/2026-05-17-sse-failure-backoff/proposal.md
+++ b/openspec/changes/archive/2026-05-17-sse-failure-backoff/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+When Miele's SSE gateway is degraded (e.g. returns `504 Gateway Time-out` from the upstream openresty proxy, as reported in issue #45), the current SSE client retries every 5 seconds indefinitely. That generates log spam, hammers an already-struggling endpoint, and gives operators no clear signal that the bridge has fallen back to polling. The polling loop already runs in parallel as a fallback (commit `7620b8e`), so devices keep updating — but the SSE side stays loud and the bridge state on MQTT is unclear. This change adds an exponential backoff to SSE reconnects after sustained failures and reports a `degraded` bridge state so users can tell the difference between "SSE is healthy" and "we're surviving on polling".
+
+## What Changes
+
+- Track consecutive SSE connection failures (any non-success outcome: build-request error, transport error, non-200 status including 504, EOF before any event, watchdog timeout before any event).
+- Apply exponential backoff to the SSE reconnect delay after a configurable failure threshold: 5s → 30s → 2m → 10m, capped at 10m. Reset to the base 5s delay as soon as a connection succeeds and dispatches at least one event.
+- Report a new bridge status value `degraded` on `bridge/miele` when the failure streak crosses the backoff threshold and polling is the de-facto source of updates. Transition back to `connected` when SSE recovers, or `disconnected` when polling is also failing.
+- Expose the failure streak and current backoff via the existing `miele` expvar surface (`sse.consecutive_failures`, `sse.next_retry_after`) for diagnostics.
+- New config field `miele.sse-backoff` (optional object) lets operators tune the threshold and ceiling without touching code. Defaults match the values above so existing configs keep working unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None — this change adjusts existing capabilities only. -->
+
+### Modified Capabilities
+
+- `miele-event-stream`: adds requirements for exponential reconnect backoff after consecutive failures and a `degraded` status value alongside `connected`/`disconnected`/`unknown`.
+- `app-config`: adds the optional `miele.sse-backoff` block (threshold, base delay, max delay) with documented defaults.
+- `runtime-metrics`: extends the `sse` expvar sub-object with `consecutive_failures` and `next_retry_after` fields.
+
+## Impact
+
+- **Affected code**: `app/miele/sse/sse.go` (failure tracking, backoff scheduling, success-reset), `app/app.go` (map the new `degraded` status to MQTT and metrics), `app/config/config.go` (new optional config block + defaults), `app/metrics/metrics.go` (two new fields in the `sse` snapshot).
+- **Behavior on existing configs**: unchanged for the first ~30 seconds of any outage — the threshold defaults to 5 consecutive failures (~25 seconds at the 5s base delay) before backoff engages, so brief blips look the same as today.
+- **MQTT contract**: a new `degraded` value can appear on `bridge/miele`. Existing subscribers that only expect `connected`/`disconnected` will see it as an unknown string; documented in README.
+- **No new external dependencies.** No change to the device-update path — devices flow through `onDevices` exactly as today during both healthy and degraded states.

--- a/openspec/changes/archive/2026-05-17-sse-failure-backoff/specs/app-config/spec.md
+++ b/openspec/changes/archive/2026-05-17-sse-failure-backoff/specs/app-config/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: SSE backoff configuration block
+
+The system SHALL accept an optional `miele.sse-backoff` object in the JSON config with three optional fields: `failure-threshold` (integer, consecutive failures before backoff engages, default `5`), `base-delay` (Go duration string, delay while below threshold, default `"5s"`), and `max-delay` (Go duration string, ceiling for the step-table delay, default `"10m"`). Duration fields SHALL be parsed via `time.ParseDuration`. Unset or zero-valued fields SHALL receive their documented defaults.
+
+#### Scenario: Defaults applied when block is absent
+
+- **WHEN** a config omits the `miele.sse-backoff` block entirely
+- **THEN** the loaded config behaves as if `failure-threshold=5`, `base-delay=5s`, `max-delay=10m`
+
+#### Scenario: Partial overrides
+
+- **WHEN** the config sets `miele.sse-backoff.failure-threshold` to `10` and leaves the other two fields unset
+- **THEN** the loaded config exposes `failure-threshold=10`, `base-delay=5s`, `max-delay=10m`
+
+#### Scenario: Custom durations parsed
+
+- **WHEN** the config sets `miele.sse-backoff.base-delay` to `"2s"` and `miele.sse-backoff.max-delay` to `"5m"`
+- **THEN** the parsed config exposes those durations
+- **AND** the step table is recomputed so the last step equals the configured max-delay
+
+#### Scenario: Invalid duration rejected at load time
+
+- **WHEN** the config sets `miele.sse-backoff.base-delay` to a value that `time.ParseDuration` cannot parse (e.g. `"five seconds"`)
+- **THEN** `LoadConfig` returns an error describing the offending field
+- **AND** the application exits non-zero (per the existing config-load failure path)
+
+### Requirement: Backwards compatibility for configs without the backoff block
+
+The system SHALL load configs written before this change without requiring edits. The new `miele.sse-backoff` block SHALL be optional in the JSON schema sense — its absence SHALL NOT cause a validation error and SHALL produce identical behavior to a block whose fields all use the documented defaults.
+
+#### Scenario: Pre-existing config loads unchanged
+
+- **WHEN** a user provides a `config.json` produced before this change
+- **THEN** the system loads it without requiring edits
+- **AND** SSE reconnects use the default backoff parameters

--- a/openspec/changes/archive/2026-05-17-sse-failure-backoff/specs/miele-event-stream/spec.md
+++ b/openspec/changes/archive/2026-05-17-sse-failure-backoff/specs/miele-event-stream/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Exponential reconnect backoff after consecutive failures
+
+The system SHALL track consecutive SSE connect failures and increase the delay between reconnect attempts according to a step table once a configurable failure threshold is reached. The streak counter SHALL increment on any of: HTTP request build failure, transport error, non-200 response status (including 504 Gateway Time-out), EOF on the response body before any `devices` event has been dispatched on that connection, and watchdog timeout. The streak counter SHALL reset to zero on the first `devices` event successfully dispatched after a (re)connect.
+
+The default step table SHALL be `5s, 30s, 2m, 10m` with the index advancing by one each failure starting at the threshold and saturating at the last step. The base delay (used while the streak is below the threshold) SHALL default to `5s` and the maximum delay (cap of the step table) SHALL default to `10m`. The default failure threshold SHALL be `5`.
+
+#### Scenario: First few failures use the base delay
+
+- **WHEN** the SSE connect attempt fails for the first time and the consecutive-failure streak (post-increment) is less than the configured threshold
+- **THEN** the system waits the base delay (default `5s`) before reconnecting
+- **AND** does NOT signal the `degraded` status
+
+#### Scenario: Backoff engages at the threshold
+
+- **WHEN** the consecutive-failure streak reaches the configured threshold (default `5`)
+- **THEN** the next reconnect delay is the first step beyond the base (default `30s`)
+- **AND** the system signals `degraded` to the status callback if the parallel polling loop has had at least one successful poll since process start
+
+#### Scenario: Backoff saturates at the maximum delay
+
+- **WHEN** the consecutive-failure streak exceeds the number of steps in the table
+- **THEN** the reconnect delay stays at the configured maximum (default `10m`) for all subsequent failures until a success resets the streak
+
+#### Scenario: Success resets the streak
+
+- **WHEN** a `devices` event is successfully dispatched after one or more failures
+- **THEN** the consecutive-failure counter resets to `0`
+- **AND** the next reconnect delay returns to the base delay
+- **AND** the system signals `connected` to the status callback
+
+#### Scenario: 504 Gateway Time-out counted as a failure
+
+- **WHEN** the SSE endpoint returns HTTP 504 (or any non-200 response)
+- **THEN** the streak counter increments
+- **AND** the response body is closed before the next attempt
+
+#### Scenario: Silent stream counted as a failure
+
+- **WHEN** an SSE connection opens successfully but the response body ends (EOF or watchdog timeout) before any `devices` event has been dispatched
+- **THEN** the streak counter increments
+- **AND** the standard backoff selection applies for the next attempt
+
+## MODIFIED Requirements
+
+### Requirement: SSE bridge status reporting
+
+The system SHALL report the SSE connection state to the MQTT layer via the values `connected`, `disconnected`, `degraded`, and `unknown` so it can be published on `bridge/miele`. `unknown` is the initial value before the first connection attempt. `connected` is reported after the body opens and is held until the connection ends. `disconnected` is reported when a connection ends or fails to establish while the failure streak is still below the configured backoff threshold. `degraded` is reported when the failure streak reaches the threshold and the parallel polling loop has had at least one successful poll since process start; it is held until SSE successfully dispatches an event again.
+
+#### Scenario: Connection successfully established
+
+- **WHEN** the SSE connection is established and the response body opens with status 200
+- **THEN** the system signals `connected` to the status callback
+
+#### Scenario: Brief disconnect below threshold
+
+- **WHEN** an SSE connection drops or fails to establish and the consecutive-failure streak (post-increment) is still below the configured threshold
+- **THEN** the system signals `disconnected` to the status callback
+
+#### Scenario: Sustained failures with polling healthy
+
+- **WHEN** the consecutive-failure streak reaches the configured threshold AND the polling loop has had at least one successful poll since process start
+- **THEN** the system signals `degraded` to the status callback
+- **AND** holds the `degraded` state across subsequent failed attempts until SSE recovers
+
+#### Scenario: Sustained failures with polling also failing
+
+- **WHEN** the consecutive-failure streak reaches the threshold AND polling has not yet had a successful poll since process start
+- **THEN** the system continues to signal `disconnected` (NOT `degraded`)
+
+#### Scenario: Recovery from degraded
+
+- **WHEN** SSE successfully dispatches a `devices` event after a `degraded` period
+- **THEN** the system signals `connected` to the status callback
+
+### Requirement: Automatic reconnect on disconnect
+
+The system SHALL, on any SSE read error, EOF, non-200 status, or watchdog timeout, close the current response body and re-establish the SSE connection until the application is stopped. The delay between attempts SHALL be selected per the exponential reconnect backoff requirement: base delay below the configured threshold, and the appropriate step from the backoff table at or beyond the threshold.
+
+#### Scenario: Stream disconnects unexpectedly
+
+- **WHEN** the underlying HTTP body returns an error or EOF
+- **THEN** the system closes the response, waits the backoff-selected delay, and reconnects with a fresh request using the current access token
+- **AND** continues this loop until a stop signal is received
+
+#### Scenario: Watchdog timeout closes the stream
+
+- **WHEN** no event has been received within the configured watchdog interval (if enabled)
+- **THEN** the system closes the SSE response so the reconnect loop establishes a new one
+- **AND** the watchdog-triggered closure counts toward the consecutive-failure streak when no event was dispatched on that connection

--- a/openspec/changes/archive/2026-05-17-sse-failure-backoff/specs/runtime-metrics/spec.md
+++ b/openspec/changes/archive/2026-05-17-sse-failure-backoff/specs/runtime-metrics/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: Miele connection state
+
+The `miele.connection` field SHALL hold the most recently observed Miele connection state, mirroring the value published on the `bridge/miele` MQTT topic: `"unknown"` before any state transition, then one of `"connected"`, `"disconnected"`, or `"degraded"`.
+
+#### Scenario: Initial value
+
+- **WHEN** the application has started but has not yet observed an SSE or polling result
+- **THEN** `miele.connection` is `"unknown"`
+
+#### Scenario: SSE connects
+
+- **WHEN** the SSE client emits `connected` via its status callback
+- **THEN** `miele.connection` becomes `"connected"`
+
+#### Scenario: SSE disconnects
+
+- **WHEN** the SSE client emits `disconnected`
+- **THEN** `miele.connection` becomes `"disconnected"`
+
+#### Scenario: SSE enters degraded mode
+
+- **WHEN** the SSE client emits `degraded` via its status callback (failure streak crossed the backoff threshold while polling is healthy)
+- **THEN** `miele.connection` becomes `"degraded"`
+
+### Requirement: SSE metrics
+
+The `miele.sse` field SHALL be a JSON object with at least the keys `last_event` (RFC3339 timestamp string, zero-valued when no event has been received), `events_total` (integer count of dispatched events since process start), `consecutive_failures` (integer count of the current connect-failure streak; reset to `0` on a dispatched event), and `next_retry_after` (RFC3339 timestamp string indicating when the next reconnect attempt is scheduled; empty string when not currently in a wait).
+
+#### Scenario: Counter increments per dispatch
+
+- **WHEN** the SSE client dispatches a `devices` event to the application
+- **THEN** `miele.sse.events_total` increases by 1
+- **AND** `miele.sse.last_event` is updated to the dispatch time
+- **AND** `miele.sse.consecutive_failures` is reset to `0`
+
+#### Scenario: No events yet
+
+- **WHEN** the process has started but no SSE event has been dispatched
+- **THEN** `miele.sse.events_total` is `0`
+- **AND** `miele.sse.last_event` is the zero-valued RFC3339 timestamp
+- **AND** `miele.sse.consecutive_failures` is `0`
+- **AND** `miele.sse.next_retry_after` is the empty string
+
+#### Scenario: Failure streak reflected in expvar
+
+- **WHEN** three SSE connect attempts fail in a row without an event dispatch in between
+- **THEN** `miele.sse.consecutive_failures` is `3`
+- **AND** `miele.sse.next_retry_after` is the RFC3339 timestamp at which the next reconnect will fire
+
+#### Scenario: Streak resets on success
+
+- **WHEN** a `devices` event is dispatched after a streak of failures
+- **THEN** `miele.sse.consecutive_failures` is `0`
+- **AND** `miele.sse.next_retry_after` is the empty string

--- a/openspec/changes/archive/2026-05-17-sse-failure-backoff/tasks.md
+++ b/openspec/changes/archive/2026-05-17-sse-failure-backoff/tasks.md
@@ -1,0 +1,57 @@
+## 1. Config schema
+
+- [x] 1.1 Add `SSEBackoffConfig` struct to `app/config/config.go` with fields `FailureThreshold int`, `BaseDelay string`, `MaxDelay string` (raw strings parsed later) and the matching `json:"failure-threshold"`, `json:"base-delay"`, `json:"max-delay"` tags. Add it under `MieleConfig` as `SSEBackoff *SSEBackoffConfig json:"sse-backoff,omitempty"`.
+- [x] 1.2 Extend `ApplyDefaults` to populate the backoff defaults when `Miele.SSEBackoff` is nil or has zero-valued fields: threshold=5, base-delay=`"5s"`, max-delay=`"10m"`.
+- [x] 1.3 Add a load-time validation step inside `LoadConfig` (or a helper called from it) that parses `BaseDelay` / `MaxDelay` with `time.ParseDuration` and returns a wrapped error naming the offending field. Store the parsed `time.Duration` values on a sibling private field (`baseDelayParsed`, `maxDelayParsed`) or expose accessor methods so the rest of the app does not re-parse.
+- [x] 1.4 Update `config_test.go`: add cases for (a) absent block uses defaults, (b) partial override keeps defaults for omitted fields, (c) custom durations parse correctly, (d) invalid duration returns an error.
+
+## 2. SSE backoff core
+
+- [x] 2.1 Extend `sse.Options` with backoff inputs: `FailureThreshold int`, `BaseReconnectDelay time.Duration`, `MaxReconnectDelay time.Duration`. Keep `ReconnectDelay` for back-compat (treated as the base if `BaseReconnectDelay` is unset). Default `FailureThreshold` to 5 when zero.
+- [x] 2.2 In `Client`, add fields `consecutiveFailures int`, `dispatchedThisConnection bool`, `nextRetryAt time.Time` guarded by the existing mutex.
+- [x] 2.3 Replace the fixed `time.After(c.opts.ReconnectDelay)` in `loop()` with a `selectBackoffDelay()` helper that returns the next delay: base while `consecutiveFailures < threshold`, otherwise the step-table value clamped to `MaxReconnectDelay`. Compute the step table once at `Start()` from base/max (multiply by ~6 per step, last step == max).
+- [x] 2.4 Increment `consecutiveFailures` on each failure path: failed `http.NewRequestWithContext`, transport `Do` error, non-200 status, `readLoop` returning without having dispatched any event on that connection (track via `dispatchedThisConnection`), and watchdog-triggered close with no dispatch. Set `dispatchedThisConnection = false` at the start of `connect()`.
+- [x] 2.5 Reset `consecutiveFailures` to 0 inside the `dispatch` closure in `readLoop` after a successful `OnDevices` call, and set `dispatchedThisConnection = true`.
+- [x] 2.6 Update `nextRetryAt` whenever `selectBackoffDelay` is computed, and clear it when entering `connect()`.
+
+## 3. Status reporting (connected / disconnected / degraded)
+
+- [x] 3.1 Add an `OnPollingHealthy func() bool` callback to `sse.Options` so the SSE client can ask the app whether the parallel polling loop has had a successful poll since process start.
+- [x] 3.2 In `loop()`, after computing the post-failure status, emit `degraded` (instead of `disconnected`) when `consecutiveFailures >= threshold` AND `OnPollingHealthy()` returns true. Below threshold, keep emitting `disconnected` exactly as today.
+- [x] 3.3 On successful event dispatch in `readLoop`, if the previous reported status was `degraded` or `disconnected`, emit `connected` (the existing `connect()` already emits `connected` once on body-open; ensure the dispatch path can flip from `degraded`→`connected` without requiring a body close/re-open).
+- [x] 3.4 In `app/app.go`, expose a `pollingHealthy()` helper that returns true once `metrics.RecordPollSuccess` has been called at least once. Wire it into `sse.Options.OnPollingHealthy` at startup.
+- [x] 3.5 Extend the SSE `OnStatus` switch in `app/app.go` to handle `degraded`: call `metrics.SetSSEConnection("degraded")` and `a.pub.PublishMieleState("degraded")`.
+
+## 4. Metrics surface
+
+- [x] 4.1 Add `sseConsecutiveFailures atomic.Int64` (or unguarded int read inside the existing mutex; pick whichever matches the surrounding pattern in `metrics.go`) and `sseNextRetryAt time.Time` to the metrics state.
+- [x] 4.2 Add `RecordSSEFailure(streak int, nextRetry time.Time)` and `RecordSSESuccess()` update funcs. Wire them from the SSE client at the same points the counter changes (after increment / after reset).
+- [x] 4.3 Update `snapshot()` to emit `consecutive_failures` and `next_retry_after` under the `sse` sub-object. `next_retry_after` is `""` when the stored time is zero, else RFC3339.
+- [x] 4.4 Update `metrics_test.go`: a streak of N failures increments `consecutive_failures` to N and sets `next_retry_after`; a success call resets both fields.
+
+## 5. App wiring
+
+- [x] 5.1 In `app/app.go:start`, pass the new backoff options into `sse.Start(...)` reading from `a.cfg.Miele.SSEBackoff`. Use the parsed `time.Duration` values; do not re-parse the strings here.
+- [x] 5.2 Keep the existing `ReconnectDelay: 5 * time.Second` line removed or adjusted so the new `BaseReconnectDelay` is authoritative.
+- [x] 5.3 Verify the polling loop's `metrics.RecordPollSuccess` callsite is the source of truth for "polling healthy" — no additional plumbing needed beyond reading the metrics counter from `pollingHealthy()`.
+
+## 6. Tests
+
+- [x] 6.1 `app/miele/sse/sse_test.go`: add a stub server that returns 504 N times then 200 with one event. Assert: `OnStatus` sees `disconnected` for the first attempts below threshold, `degraded` once at-and-beyond threshold (with `OnPollingHealthy` returning true), then `connected` after the successful dispatch. Verify the streak reset is observable via injected callback.
+- [x] 6.2 Test: with `OnPollingHealthy` returning false, the streak crossing the threshold still produces `disconnected` (NOT `degraded`).
+- [x] 6.3 Test: a connection that opens 200 but the body returns EOF before any event counts as a failure (streak increments).
+- [x] 6.4 Test: watchdog timeout with no dispatched event counts as a failure; watchdog timeout after at least one dispatched event does NOT count (the dispatch had already reset the streak).
+- [x] 6.5 Test the backoff step-table calculation directly: with base=5s, max=10m, the table is `[5s, 30s, 2m, 10m]` (or similar — assert the boundary conditions: first step > base, last step == max, monotonic).
+- [x] 6.6 Run `go test -race ./...` and ensure no new data-race findings.
+
+## 7. Documentation
+
+- [x] 7.1 Update `README.md` bridge-status documentation to list all four values (`unknown`, `connected`, `disconnected`, `degraded`) with a one-line meaning each. Note that `degraded` means "SSE has been failing but polling is still delivering device updates".
+- [x] 7.2 Add a `miele.sse-backoff` block to `config-example.json` (commented as optional) showing the default values.
+- [x] 7.3 Update the README diagnostics section to mention the two new expvar fields under `miele.sse`.
+
+## 8. Validation
+
+- [x] 8.1 Run `go test ./...` and `go vet ./...` — clean.
+- [x] 8.2 Run `openspec validate sse-failure-backoff --strict` — clean.
+- [ ] 8.3 Manual: with a config pointing at a stub server that returns 504, observe (a) reconnect delay growth over time, (b) `bridge/miele` transitions through `disconnected` → `degraded` once polling succeeds at least once, (c) recovery to `connected` when the stub returns events. Flag as pending if a live Miele account is required.

--- a/openspec/specs/app-config/spec.md
+++ b/openspec/specs/app-config/spec.md
@@ -80,3 +80,39 @@ The system SHALL, when `miele.token.access` and `miele.token.refresh` are presen
 - **WHEN** the loaded config has `miele.token` populated with valid `access`, `refresh`, and `validUntil`
 - **THEN** the system uses that token for the first API call without performing a username/password login
 
+### Requirement: SSE backoff configuration block
+
+The system SHALL accept an optional `miele.sse-backoff` object in the JSON config with three optional fields: `failure-threshold` (integer, consecutive failures before backoff engages, default `5`), `base-delay` (Go duration string, delay while below threshold, default `"5s"`), and `max-delay` (Go duration string, ceiling for the step-table delay, default `"10m"`). Duration fields SHALL be parsed via `time.ParseDuration`. Unset or zero-valued fields SHALL receive their documented defaults.
+
+#### Scenario: Defaults applied when block is absent
+
+- **WHEN** a config omits the `miele.sse-backoff` block entirely
+- **THEN** the loaded config behaves as if `failure-threshold=5`, `base-delay=5s`, `max-delay=10m`
+
+#### Scenario: Partial overrides
+
+- **WHEN** the config sets `miele.sse-backoff.failure-threshold` to `10` and leaves the other two fields unset
+- **THEN** the loaded config exposes `failure-threshold=10`, `base-delay=5s`, `max-delay=10m`
+
+#### Scenario: Custom durations parsed
+
+- **WHEN** the config sets `miele.sse-backoff.base-delay` to `"2s"` and `miele.sse-backoff.max-delay` to `"5m"`
+- **THEN** the parsed config exposes those durations
+- **AND** the step table is recomputed so the last step equals the configured max-delay
+
+#### Scenario: Invalid duration rejected at load time
+
+- **WHEN** the config sets `miele.sse-backoff.base-delay` to a value that `time.ParseDuration` cannot parse (e.g. `"five seconds"`)
+- **THEN** `LoadConfig` returns an error describing the offending field
+- **AND** the application exits non-zero (per the existing config-load failure path)
+
+### Requirement: Backwards compatibility for configs without the backoff block
+
+The system SHALL load configs written before this change without requiring edits. The new `miele.sse-backoff` block SHALL be optional in the JSON schema sense — its absence SHALL NOT cause a validation error and SHALL produce identical behavior to a block whose fields all use the documented defaults.
+
+#### Scenario: Pre-existing config loads unchanged
+
+- **WHEN** a user provides a `config.json` produced before this change
+- **THEN** the system loads it without requiring edits
+- **AND** SSE reconnects use the default backoff parameters
+

--- a/openspec/specs/miele-event-stream/spec.md
+++ b/openspec/specs/miele-event-stream/spec.md
@@ -15,18 +15,19 @@ The system SHALL, when `miele.mode` is `sse`, open a long-lived HTTP request to 
 
 ### Requirement: Automatic reconnect on disconnect
 
-The system SHALL, on any SSE read error, EOF, or watchdog timeout, close the current response body and re-establish the SSE connection until the application is stopped.
+The system SHALL, on any SSE read error, EOF, non-200 status, or watchdog timeout, close the current response body and re-establish the SSE connection until the application is stopped. The delay between attempts SHALL be selected per the exponential reconnect backoff requirement: base delay below the configured threshold, and the appropriate step from the backoff table at or beyond the threshold.
 
 #### Scenario: Stream disconnects unexpectedly
 
 - **WHEN** the underlying HTTP body returns an error or EOF
-- **THEN** the system closes the response, waits a short backoff (5 seconds), and reconnects with a fresh request using the current access token
+- **THEN** the system closes the response, waits the backoff-selected delay, and reconnects with a fresh request using the current access token
 - **AND** continues this loop until a stop signal is received
 
 #### Scenario: Watchdog timeout closes the stream
 
 - **WHEN** no event has been received within the configured watchdog interval (if enabled)
 - **THEN** the system closes the SSE response so the reconnect loop establishes a new one
+- **AND** the watchdog-triggered closure counts toward the consecutive-failure streak when no event was dispatched on that connection
 
 ### Requirement: Restart on token-refresh boundary
 
@@ -41,14 +42,33 @@ The system SHALL close the SSE stream and re-open it with a fresh token whenever
 
 ### Requirement: SSE bridge status reporting
 
-The system SHALL report the SSE connection state to the MQTT layer via the values `connected` and `disconnected` (and `unknown` before the first attempt) so it can be published on `bridge/miele`.
+The system SHALL report the SSE connection state to the MQTT layer via the values `connected`, `disconnected`, `degraded`, and `unknown` so it can be published on `bridge/miele`. `unknown` is the initial value before the first connection attempt. `connected` is reported after the body opens and is held until the connection ends. `disconnected` is reported when a connection ends or fails to establish while the failure streak is still below the configured backoff threshold. `degraded` is reported when the failure streak reaches the threshold and the parallel polling loop has had at least one successful poll since process start; it is held until SSE successfully dispatches an event again.
 
-#### Scenario: Connection state changes
+#### Scenario: Connection successfully established
 
-- **WHEN** the SSE connection is successfully established
+- **WHEN** the SSE connection is established and the response body opens with status 200
 - **THEN** the system signals `connected` to the status callback
-- **WHEN** the SSE connection drops or fails to establish
+
+#### Scenario: Brief disconnect below threshold
+
+- **WHEN** an SSE connection drops or fails to establish and the consecutive-failure streak (post-increment) is still below the configured threshold
 - **THEN** the system signals `disconnected` to the status callback
+
+#### Scenario: Sustained failures with polling healthy
+
+- **WHEN** the consecutive-failure streak reaches the configured threshold AND the polling loop has had at least one successful poll since process start
+- **THEN** the system signals `degraded` to the status callback
+- **AND** holds the `degraded` state across subsequent failed attempts until SSE recovers
+
+#### Scenario: Sustained failures with polling also failing
+
+- **WHEN** the consecutive-failure streak reaches the threshold AND polling has not yet had a successful poll since process start
+- **THEN** the system continues to signal `disconnected` (NOT `degraded`)
+
+#### Scenario: Recovery from degraded
+
+- **WHEN** SSE successfully dispatches a `devices` event after a `degraded` period
+- **THEN** the system signals `connected` to the status callback
 
 ### Requirement: Graceful shutdown
 
@@ -58,4 +78,46 @@ The system SHALL stop the SSE reader, watchdog goroutine, and reconnect loop cle
 
 - **WHEN** the application's shutdown hook is invoked
 - **THEN** the SSE client closes its current connection, stops its watchdog ticker, and exits its reconnect loop without leaking goroutines
+
+### Requirement: Exponential reconnect backoff after consecutive failures
+
+The system SHALL track consecutive SSE connect failures and increase the delay between reconnect attempts according to a step table once a configurable failure threshold is reached. The streak counter SHALL increment on any of: HTTP request build failure, transport error, non-200 response status (including 504 Gateway Time-out), EOF on the response body before any `devices` event has been dispatched on that connection, and watchdog timeout. The streak counter SHALL reset to zero on the first `devices` event successfully dispatched after a (re)connect.
+
+The default step table SHALL be `5s, 30s, 2m, 10m` with the index advancing by one each failure starting at the threshold and saturating at the last step. The base delay (used while the streak is below the threshold) SHALL default to `5s` and the maximum delay (cap of the step table) SHALL default to `10m`. The default failure threshold SHALL be `5`.
+
+#### Scenario: First few failures use the base delay
+
+- **WHEN** the SSE connect attempt fails for the first time and the consecutive-failure streak (post-increment) is less than the configured threshold
+- **THEN** the system waits the base delay (default `5s`) before reconnecting
+- **AND** does NOT signal the `degraded` status
+
+#### Scenario: Backoff engages at the threshold
+
+- **WHEN** the consecutive-failure streak reaches the configured threshold (default `5`)
+- **THEN** the next reconnect delay is the first step beyond the base (default `30s`)
+- **AND** the system signals `degraded` to the status callback if the parallel polling loop has had at least one successful poll since process start
+
+#### Scenario: Backoff saturates at the maximum delay
+
+- **WHEN** the consecutive-failure streak exceeds the number of steps in the table
+- **THEN** the reconnect delay stays at the configured maximum (default `10m`) for all subsequent failures until a success resets the streak
+
+#### Scenario: Success resets the streak
+
+- **WHEN** a `devices` event is successfully dispatched after one or more failures
+- **THEN** the consecutive-failure counter resets to `0`
+- **AND** the next reconnect delay returns to the base delay
+- **AND** the system signals `connected` to the status callback
+
+#### Scenario: 504 Gateway Time-out counted as a failure
+
+- **WHEN** the SSE endpoint returns HTTP 504 (or any non-200 response)
+- **THEN** the streak counter increments
+- **AND** the response body is closed before the next attempt
+
+#### Scenario: Silent stream counted as a failure
+
+- **WHEN** an SSE connection opens successfully but the response body ends (EOF or watchdog timeout) before any `devices` event has been dispatched
+- **THEN** the streak counter increments
+- **AND** the standard backoff selection applies for the next attempt
 

--- a/openspec/specs/runtime-metrics/spec.md
+++ b/openspec/specs/runtime-metrics/spec.md
@@ -15,7 +15,7 @@ The system SHALL publish exactly one top-level `expvar` named `miele` reachable 
 
 ### Requirement: Miele connection state
 
-The `miele.connection` field SHALL hold the most recently observed Miele connection state, mirroring the value published on the `bridge/miele` MQTT topic: `"unknown"` before any state transition, then `"connected"` or `"disconnected"`.
+The `miele.connection` field SHALL hold the most recently observed Miele connection state, mirroring the value published on the `bridge/miele` MQTT topic: `"unknown"` before any state transition, then one of `"connected"`, `"disconnected"`, or `"degraded"`.
 
 #### Scenario: Initial value
 
@@ -31,6 +31,11 @@ The `miele.connection` field SHALL hold the most recently observed Miele connect
 
 - **WHEN** the SSE client emits `disconnected`
 - **THEN** `miele.connection` becomes `"disconnected"`
+
+#### Scenario: SSE enters degraded mode
+
+- **WHEN** the SSE client emits `degraded` via its status callback (failure streak crossed the backoff threshold while polling is healthy)
+- **THEN** `miele.connection` becomes `"degraded"`
 
 ### Requirement: Per-device snapshot
 
@@ -50,19 +55,34 @@ The `miele.devices` field SHALL be a JSON object keyed by device id, whose value
 
 ### Requirement: SSE metrics
 
-The `miele.sse` field SHALL be a JSON object with at least the keys `last_event` (RFC3339 timestamp string, zero-valued when no event has been received) and `events_total` (integer count of dispatched events since process start).
+The `miele.sse` field SHALL be a JSON object with at least the keys `last_event` (RFC3339 timestamp string, zero-valued when no event has been received), `events_total` (integer count of dispatched events since process start), `consecutive_failures` (integer count of the current connect-failure streak; reset to `0` on a dispatched event), and `next_retry_after` (RFC3339 timestamp string indicating when the next reconnect attempt is scheduled; empty string when not currently in a wait).
 
 #### Scenario: Counter increments per dispatch
 
 - **WHEN** the SSE client dispatches a `devices` event to the application
 - **THEN** `miele.sse.events_total` increases by 1
 - **AND** `miele.sse.last_event` is updated to the dispatch time
+- **AND** `miele.sse.consecutive_failures` is reset to `0`
 
 #### Scenario: No events yet
 
 - **WHEN** the process has started but no SSE event has been dispatched
 - **THEN** `miele.sse.events_total` is `0`
 - **AND** `miele.sse.last_event` is the zero-valued RFC3339 timestamp
+- **AND** `miele.sse.consecutive_failures` is `0`
+- **AND** `miele.sse.next_retry_after` is the empty string
+
+#### Scenario: Failure streak reflected in expvar
+
+- **WHEN** three SSE connect attempts fail in a row without an event dispatch in between
+- **THEN** `miele.sse.consecutive_failures` is `3`
+- **AND** `miele.sse.next_retry_after` is the RFC3339 timestamp at which the next reconnect will fire
+
+#### Scenario: Streak resets on success
+
+- **WHEN** a `devices` event is dispatched after a streak of failures
+- **THEN** `miele.sse.consecutive_failures` is `0`
+- **AND** `miele.sse.next_retry_after` is the empty string
 
 ### Requirement: Polling metrics
 


### PR DESCRIPTION
Track consecutive SSE failures and apply a step-table backoff (5s → 30s → 2m → 10m) once the failure streak crosses a configurable threshold, instead of hammering the endpoint every 5s indefinitely.

Publish a new `degraded` value on `bridge/miele` when SSE is failing but the parallel polling loop is healthy, so operators can tell "SSE recovered" apart from "we're surviving on polling". Reset to `connected` and the base delay on the first successful event.

Expose `sse.consecutive_failures` and `sse.next_retry_after` on the runtime metrics expvar surface, and add an optional `miele.sse-backoff` config block (threshold, base-delay, max-delay) with defaults that match the previous 5s cadence for the first ~25 seconds of any outage.

fixes: https://github.com/mqtt-home/miele-to-mqtt-gw/issues/45